### PR TITLE
feat(fieldset.html): add support for django 5.2

### DIFF
--- a/suit/templates/admin/includes/fieldset.html
+++ b/suit/templates/admin/includes/fieldset.html
@@ -1,76 +1,74 @@
 {% load suit_tags %}
 <fieldset class="module aligned{{ fieldset.name|yesno:' with-legend, first' }} {{ fieldset.classes }}">
-    {% if fieldset.name %}
-        <h2 class="legend">{{ fieldset.name }}
-            {% if fieldset.description %}
-                <span class="description">{{ fieldset.description|safe }}</span>
-            {% endif %}
+  {% if fieldset.name %}
+    <h2 class="legend">{{ fieldset.name }}
+      {% if fieldset.description %}
+        <span class="description">{{ fieldset.description|safe }}</span>
+      {% endif %}
         </h2>{% endif %}
   {% for line in fieldset %}
-    {% with singlefield=line.fields|length_is:'1' %}
-      <div class="control-group form-row{% if line.errors %} {{ singlefield|yesno:'error,first-error' }} errors{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %} {{ field.field.field.widget.attrs.rowclass }}{% endfor %}{{ singlefield|yesno:',multi-field-row' }}">
+    {% with fields_count=line.fields|length %}
+      <div class="control-group form-row{% if line.errors %} {% if fields_count == 1 %}error{% else %}first-error{% endif %} errors{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %} {{ field.field.field.widget.attrs.rowclass }}{% endfor %}{% if fields_count != 1 %} multi-field-row{% endif %}">
         {% for field in line %}
           {% spaceless %}
 
-        {# write special control tags only for first multi field #}
-        {% if forloop.first %}
-            <div{% if not singlefield %}
-                class="field-box{% if field.field.name %} field-{{ field.field.name }}{% endif %}"{% endif %}>
-
-            <div class="control-label">
+          {# write special control tags only for first multi field #}
+          {% if forloop.first %}
+            <div{% if fields_count != 1 %} class="field-box{% if field.field.name %} field-{{ field.field.name }}{% endif %}"{% endif %}>
+              <div class="control-label">
                 {{ field.label_tag }}
-            </div>
-            <div class="controls">
-            {# if multi-fields and first field #}
-            {% if not singlefield %}
-              <div class="multi-field-box">
+              </div>
+              <div class="controls">
+                {# if multi-fields and first field #}
+              {% if fields_count != 1 %}
+                  <div class="multi-field-box">
+                {% endif %}
+          {% else %}
+            {# If multi-fields and not first wrap also label #}
+            {% if fields_count != 1 and not forloop.first %}
+              <div class="multi-field-box{{ field.errors|yesno:' error,' }}">
             {% endif %}
-        {% else %}
-          {# If multi-fields and not first wrap also label #}
-          {% if not singlefield and not forloop.first %}
-            <div class="multi-field-box{{ field.errors|yesno:' error,' }}">
-          {% endif %}
             {{ field.label_tag }}
-        {% endif %}
+          {% endif %}
 
-        {% if not field.is_readonly and field.errors %}<div class="inline error errors">{% endif %}
+          {% if not field.is_readonly and field.errors %}<div class="inline error errors">{% endif %}
 
-        {# If multi-fields and wrap controls too #}
-         {% if not singlefield %}
+{# If multi-fields and wrap controls too #}
+          {% if fields_count != 1 %}
             <div class="multi-field-controls">
           {% endif %}
 
-        {% if field.is_readonly %}
+          {% if field.is_readonly %}
             <span class="readonly">{{ field|field_contents_foreign_linked }}</span>
-        {% else %}
+          {% else %}
             {{ field.field }}
-        {% endif %}
+          {% endif %}
 
-        {# For single field errors#}
-        {% if singlefield and line.errors %}
+          {# For single field errors#}
+          {% if fields_count == 1 and line.errors %}
             <span class="help-inline">{{ line.errors }}</span>
-        {% endif %}
+          {% endif %}
 
-        {# For multi field errors #}
-        {% if field.errors and not singlefield and not field.is_readonly %}
-          <span class="help-block">{{ field.errors|striptags }}</span>
-        {% endif %}
+          {# For multi field errors #}
+          {% if field.errors and fields_count != 1 and not field.is_readonly %}
+            <span class="help-block">{{ field.errors|striptags }}</span>
+          {% endif %}
 
-        {% if field.field.help_text %}
-          <span class="{% if line.errors or field.errors or not singlefield %}help-block{% else %}help-inline{% endif %}">{{ field.field.help_text|safe }}</span>
-        {% endif %}
+          {% if field.field.help_text %}
+            <span class="{% if line.errors or field.errors or fields_count != 1 %}help-block{% else %}help-inline{% endif %}">{{ field.field.help_text|safe }}</span>
+          {% endif %}
 
-        {% if not field.is_readonly and field.errors %}</div>{% endif %}
+          {% if not field.is_readonly and field.errors %}</div>{% endif %}
 
-        {% if not singlefield %}
-         </div> {# close multi-controls #}
-         </div> {# close multi-field-box #}
-        {% endif %}
+          {% if fields_count != 1 %}
+            </div> {# close multi-controls #}
+          </div> {# close multi-field-box #}
+          {% endif %}
 
-        {% if forloop.last %}
+          {% if forloop.last %}
+              </div>
             </div>
-            </div>
-        {% endif %}
+          {% endif %}
 
           {% endspaceless %}
         {% endfor %}


### PR DESCRIPTION
According to the Django 5.1 release note, the `length_is` template filter was removed. So we need to adapt the only template that used it : `fieldset.html`

Django 5.1 release note : https://docs.djangoproject.com/en/6.0/releases/5.1/#features-removed-in-5-1